### PR TITLE
Fixed problem siamese example

### DIFF
--- a/examples/mnist_siamese.py
+++ b/examples/mnist_siamese.py
@@ -64,7 +64,7 @@ def create_pairs(x, digit_indices):
             z1, z2 = digit_indices[d][i], digit_indices[dn][i]
             pairs += [[x[z1], x[z2]]]
             labels += [1, 0]
-    return np.array(pairs), np.array(labels)
+    return np.array(pairs), np.array(labels).astype('float32')
 
 
 def create_base_network(input_shape):


### PR DESCRIPTION
Simple bug fix
The custom loss required labels to be in float32 type. I have changed the "generator" (create_pairs) to output the expected type

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/keras-team/keras/blob/master/CONTRIBUTING.md

Note:
We are no longer adding new features to multi-backend Keras (we only fix bugs), as we are refocusing development efforts on tf.keras. If you are still interested in submitting a feature pull request, please direct it to tf.keras in the TensorFlow repository instead.
-->

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [ ] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
- [x] None of the above. Just a simple bug fix